### PR TITLE
Feature/java17 nashorn support

### DIFF
--- a/karate-apache-async/pom.xml
+++ b/karate-apache-async/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>0.9.0-OPENET</version>
+        <version>0.9.0-OPENET-2-SNAPSHOT</version>
     </parent>
     <artifactId>karate-apache-async</artifactId>
     <packaging>jar</packaging>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-core</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
         </dependency>
         
         <dependency>

--- a/karate-apache/pom.xml
+++ b/karate-apache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>0.9.0-OPENET</version>
+        <version>0.9.0-OPENET-2-SNAPSHOT</version>
     </parent>
     <artifactId>karate-apache</artifactId>
     <packaging>jar</packaging>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-core</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
         </dependency>
         
         <dependency>

--- a/karate-archetype/pom.xml
+++ b/karate-archetype/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>0.9.0-OPENET</version>
+        <version>0.9.0-OPENET-2-SNAPSHOT</version>
     </parent>
     <artifactId>karate-archetype</artifactId>
     <packaging>jar</packaging>

--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -118,7 +118,37 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>                   
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven.shade.version}</version>
+                <executions>
+                    <execution>
+                        <id>relocate-nashorn</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>openjdk-nashorn</shadedClassifierName>
+                            <artifactSet>
+                                <includes>
+                                    <include>${project.groupId}:${project.artifactId}</include>
+                                </includes>
+                            </artifactSet>
+                            <!-- Relocate Nashorn imports to be compatible with OpenJDK Nashorn -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>jdk.nashorn</pattern>
+                                    <shadedPattern>org.openjdk.nashorn</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>                 
         </plugins>               
     </build>
     

--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>0.9.0-OPENET</version>
+        <version>0.9.0-OPENET-2-SNAPSHOT</version>
     </parent>
     
     <artifactId>karate-core</artifactId>

--- a/karate-core/src/main/java/com/intuit/karate/ScriptBindings.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScriptBindings.java
@@ -49,8 +49,24 @@ import javax.script.ScriptEngineManager;
  */
 public class ScriptBindings implements Bindings {
 
+    private static final String SCRIPT_ENGINE_NAME = "nashorn";
+
     // all threads will share this ! thread isolation is via Bindings (this class)
-    private static final ScriptEngine NASHORN = new ScriptEngineManager(null).getEngineByName("nashorn");
+    private static final ScriptEngine NASHORN;
+
+    static {
+        // Check using the extensions/platform classloader first for Nashorn engine
+        ScriptEngine scriptEngine = new ScriptEngineManager(null).getEngineByName(SCRIPT_ENGINE_NAME);
+        if (scriptEngine == null) {
+            // For Java 17, nashorn-core will be available in the application classloader, as not part of JDK
+            scriptEngine = new ScriptEngineManager().getEngineByName(SCRIPT_ENGINE_NAME);
+
+            if (scriptEngine == null) {
+                throw new RuntimeException(SCRIPT_ENGINE_NAME + " script engine not found");
+            }
+        }
+        NASHORN = scriptEngine;
+    }
     
     protected final ScriptBridge bridge;
 

--- a/karate-demo/pom.xml
+++ b/karate-demo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>0.9.0-OPENET</version>
+        <version>0.9.0-OPENET-2-SNAPSHOT</version>
     </parent>
     
     <artifactId>karate-demo</artifactId>
@@ -59,19 +59,19 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-junit4</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-netty</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-apache-async</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>                
         <dependency>

--- a/karate-gatling/pom.xml
+++ b/karate-gatling/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>0.9.0-OPENET</version>
+        <version>0.9.0-OPENET-2-SNAPSHOT</version>
     </parent>
     <artifactId>karate-gatling</artifactId>
     <packaging>jar</packaging>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-core</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.gatling.highcharts</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-netty</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>                
     </dependencies>

--- a/karate-jersey/pom.xml
+++ b/karate-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>0.9.0-OPENET</version>
+        <version>0.9.0-OPENET-2-SNAPSHOT</version>
     </parent>
     <artifactId>karate-jersey</artifactId>
     <packaging>jar</packaging>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-core</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
         </dependency>        
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
@@ -45,13 +45,13 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-demo</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>        
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-netty</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>                                                                                                                         		
     </dependencies>      

--- a/karate-junit4/pom.xml
+++ b/karate-junit4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>0.9.0-OPENET</version>
+        <version>0.9.0-OPENET-2-SNAPSHOT</version>
     </parent>
     <artifactId>karate-junit4</artifactId>
     <packaging>jar</packaging>   
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-core</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-apache-async</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>        
         <dependency>

--- a/karate-junit5/pom.xml
+++ b/karate-junit5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>0.9.0-OPENET</version>
+        <version>0.9.0-OPENET-2-SNAPSHOT</version>
     </parent>
     <artifactId>karate-junit5</artifactId>
     <packaging>jar</packaging>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-core</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-apache-async</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/karate-mock-servlet/pom.xml
+++ b/karate-mock-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>0.9.0-OPENET</version>
+        <version>0.9.0-OPENET-2-SNAPSHOT</version>
     </parent>
     
     <artifactId>karate-mock-servlet</artifactId>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-apache-async</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
         </dependency>        
         <dependency>
             <groupId>org.springframework</groupId>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-junit4</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-demo</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>               
         

--- a/karate-netty/pom.xml
+++ b/karate-netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>0.9.0-OPENET</version>
+        <version>0.9.0-OPENET-2-SNAPSHOT</version>
     </parent>
     <artifactId>karate-netty</artifactId>
     <packaging>jar</packaging>   
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-apache-async</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-junit4</artifactId>
-            <version>0.9.0-OPENET</version>
+            <version>0.9.0-OPENET-2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>                                                                                                                                                                                         		
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.intuit.karate</groupId>
     <artifactId>karate-parent</artifactId>
-    <version>0.9.0-OPENET</version>
+    <version>0.9.0-OPENET-2-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     


### PR DESCRIPTION
# Support for `nashorn-core` on Java 17

* Since `nashorn-core` for Java 17 will be on application classpath, rather than part of JDK, existing `ScriptManager` call to find engine fails. Leave current mechanism for Java 8, and if it fails, then try different `ScriptManager` construction so ServiceLoader uses the application classloader (rather than platform classloader).
* OpenJDK Nashorn has repackaged the classes. We maintain existing `karate-core` artifact, but produce a second artifact that relocates the packages.

